### PR TITLE
Fix MoGe default pre-processing config

### DIFF
--- a/data_processing/wai_processing/configs/moge/default.yaml
+++ b/data_processing/wai_processing/configs/moge/default.yaml
@@ -1,6 +1,6 @@
 root: # needs to be set via argument: root=<wai_dataset_root_path>
 
-model_path: /fsx/xrtech/checkpoints/MoGe/moge-2-vitl-normal/model.pt
+model_path: Ruicheng/moge-2-vitl-normal
 model_name: moge2
 out_path: moge/v0
 device: cuda


### PR DESCRIPTION
Change default behaviour to download the MoGe model from Hugging Face instead of using hard-coded checkpoint path